### PR TITLE
Extern build issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,17 @@
 # Using u-boot on Creator (Ci40) Marduk platform
 
-### How to build/cross-compile for Ci40:
+## Toolchain setup
+If you are using the toolchain produced by OpenWrt you must setup the environment as explained
+[here](https://wiki.openwrt.org/doc/devel/crosscompile).
 
-	$ export CROSS_COMPILE=/path/to/mips-toolchain/mips-toolchain-prefix
-	$ make pistachio_marduk_defconfig
-	$ make
+For the MIPS official toolchain see
+[here](https://community.imgtec.com/developers/mips/tools/codescape-mips-sdk/download-codescape-mips-sdk-essentials/).
+
+## Configure and build it
+	$ make CROSS_COMPILE=<toolchain-prefix> pistachio_marduk_defconfig
+	$ make CROSS_COMPILE=<toolchain-prefix>
 
 This will generate u-boot-pistachio-nor.img
 
-Note: Using OpenWrt's toolchain toolchain-mipsel_mips32_gcc-5.2.0_musl-1.1.11 will require [this patch](http://lists.denx.de/pipermail/u-boot/2015-July/217911.html) to be applied.
-
-### How to flash on Ci40:
-
-1. [Load OpenWrt](https://github.com/IMGCreator/openwrt/blob/master-pistachio/README.md)
-
-2. Erase and write u-boot image on bootloader partition of Ci40
-
-		$ flashcp -v u-boot-pistachio-nor.img /dev/mtd0
-
-	Note: flashcp needs to be manually selected in OpneWrt menuconfig
-
-		Base system -> busybox -> Cutomize busybox options -> Miscellaneous Utilities -> flashcp
-
-3. Reboot
-
-		$ reboot
-
-	Once restarted the board, you should see the date when you have built the u-boot on the console as follows:
-
-		U-Boot SPL 2015.07-rc2 (Jun 14 2016 - 19:20:36)
-		
-		
-		U-Boot 2015.07-rc2 (Jun 14 2016 - 19:20:36 +0530)
-		
-		MIPS(interAptiv): IMG Pistachio 546MHz.
-		Model: IMG Marduk
-		DRAM:  256 MiB
-		NAND:  512 MiB
-		MMC:   Synopsys Mobile storage: 0
-		SF: Detected W25Q16CL with page size 256 Bytes, erase size 4 KiB, total 2 MiB
-
-This means your built u-boot image has been flashed properly on the board!!
-
-_Please be aware that you may brick the board if you flashed a wrong bootloader. Only way to re-cover back the board is to use Dedi-prog SF100 programmer to flash the pre-built bootloader again._
+## Flash it onto your Ci40
+See our [docs](https://docs.creatordev.io/ci40/guides/openwrt-platform/#flashing-u-boot-binary).

--- a/arch/mips/include/asm/io.h
+++ b/arch/mips/include/asm/io.h
@@ -560,12 +560,12 @@ static inline void unmap_physmem(void *vaddr, unsigned long flags)
 
 #ifdef CONFIG_PHYS_TO_BUS
 
-extern inline unsigned long phys_to_bus(unsigned long phys)
+static inline unsigned long phys_to_bus(unsigned long phys)
 {
 	return (unsigned long) virt_to_phys((void * )phys);
 }
 
-extern inline unsigned long bus_to_phys(unsigned long bus)
+static inline unsigned long bus_to_phys(unsigned long bus)
 {
 	return (unsigned long) phys_to_virt(bus);
 }

--- a/arch/mips/include/asm/io.h
+++ b/arch/mips/include/asm/io.h
@@ -117,7 +117,7 @@ static inline void set_io_port_base(unsigned long base)
  * Change virtual addresses to physical addresses and vv.
  * These are trivial on the 1:1 Linux/MIPS mapping
  */
-extern inline phys_addr_t virt_to_phys(volatile void * address)
+static inline phys_addr_t virt_to_phys(volatile void * address)
 {
 #ifndef CONFIG_64BIT
 	return CPHYSADDR(address);
@@ -126,7 +126,7 @@ extern inline phys_addr_t virt_to_phys(volatile void * address)
 #endif
 }
 
-extern inline void * phys_to_virt(unsigned long address)
+static inline void * phys_to_virt(unsigned long address)
 {
 #ifndef CONFIG_64BIT
 	return (void *)KSEG0ADDR(address);

--- a/include/phys2bus.h
+++ b/include/phys2bus.h
@@ -8,8 +8,8 @@
 #define _BUS_ADDR_H
 
 #ifdef CONFIG_PHYS_TO_BUS
-unsigned long phys_to_bus(unsigned long phys);
-unsigned long bus_to_phys(unsigned long bus);
+static unsigned long phys_to_bus(unsigned long phys);
+static unsigned long bus_to_phys(unsigned long bus);
 #else
 static inline unsigned long phys_to_bus(unsigned long phys)
 {


### PR DESCRIPTION
Cleaned up some 'static' changes that had been pulled in when moving to newer u-boot but not changed for equivalent funtion.

This means that gcc 5.x build issues go away.

This work connects to #9
