### PR TITLE
mkimage: fit: check cmd string for buffer overflow

### DIFF
--- a/tools/fit_image.c
+++ b/tools/fit_image.c
@@ -96,7 +96,7 @@ static int fit_handle_file(struct image_tool_params *params)
 	if (strlen (params->imagefile) +
 		strlen (MKIMAGE_TMPFILE_SUFFIX) + 1 > sizeof (tmpfile)) {
 		fprintf (stderr, "%s: Image file name (%s) too long, "
-				"can't create tmpfile",
+				"can't create tmpfile\n",
 				params->imagefile, params->cmdname);
 		return (EXIT_FAILURE);
 	}
@@ -105,12 +105,16 @@ static int fit_handle_file(struct image_tool_params *params)
 	/* We either compile the source file, or use the existing FIT image */
 	if (params->datafile) {
 		/* dtc -I dts -O dtb -p 500 datafile > tmpfile */
-		snprintf(cmd, sizeof(cmd), "%s %s %s > %s",
+		ret = snprintf(cmd, sizeof(cmd), "%s %s %s > %s",
 			 MKIMAGE_DTC, params->dtc, params->datafile, tmpfile);
-		debug("Trying to execute \"%s\"\n", cmd);
 	} else {
-		snprintf(cmd, sizeof(cmd), "cp %s %s",
+		ret = snprintf(cmd, sizeof(cmd), "cp %s %s",
 			 params->imagefile, tmpfile);
+	}
+	debug("Trying to execute \"%s\"\n", cmd);
+	if (ret >= sizeof(cmd)) {
+		fprintf (stderr, "Command too long, can't create fit image\n");
+		return (EXIT_FAILURE);
 	}
 	if (system (cmd) == -1) {
 		fprintf (stderr, "%s: system(%s) failed: %s\n",

--- a/tools/mkimage.h
+++ b/tools/mkimage.h
@@ -43,7 +43,7 @@ static inline ulong map_to_sysmem(void *ptr)
 #define MKIMAGE_TMPFILE_SUFFIX		".tmp"
 #define MKIMAGE_MAX_TMPFILE_LEN		256
 #define MKIMAGE_DEFAULT_DTC_OPTIONS	"-I dts -O dtb -p 500"
-#define MKIMAGE_MAX_DTC_CMDLINE_LEN	512
+#define MKIMAGE_MAX_DTC_CMDLINE_LEN	1024
 #define MKIMAGE_DTC			"dtc"   /* assume dtc is in $PATH */
 
 #endif /* _MKIIMAGE_H_ */


### PR DESCRIPTION
When generating the command to create the fit image the inputs are
file paths which can overflow the buffer. snprintf was being used to
avoid the overflow itself but nothing actually checks if a
truncation occured giving unexpected filenames causing following
stages to fail.

Therefore add some checks before attempting to run the command.

Additionally have bumped up the size of the buffer as the current
inputs can easily get truncated with long paths.

Signed-off-by: Ian Pozella <Ian.Pozella@imgtec.com>