### PR TITLE
Add version to uboot image name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,14 +3,25 @@ node('docker && imgtec') {
     docker_image = docker.image "imgtec/creator-builder:latest" // TODO for now using the creator one
     docker_image.inside {
         stage('Prepare') {
-            checkout scm
+            checkout([$class: 'GitSCM',
+                userRemoteConfigs: scm.userRemoteConfigs,
+                branches: scm.branches,
+                doGenerateSubmoduleConfigurations: scm.doGenerateSubmoduleConfigurations,
+                submoduleCfg: scm.submoduleCfg,
+                browser: scm.browser,
+                gitTool: scm.gitTool,
+                extensions: scm.extensions + [
+                    [$class: 'CleanCheckout'],
+                    [$class: 'PruneStaleBranch'],
+                ],
+            ])
         }
         stage('Build') {
             sh 'make CROSS_COMPILE=/opt/toolchains/mips-img-linux-gnu/2016.05-03/bin/mips-img-linux-gnu- pistachio_marduk_defconfig'
             sh 'make CROSS_COMPILE=/opt/toolchains/mips-img-linux-gnu/2016.05-03/bin/mips-img-linux-gnu-'
         }
         stage('Upload') {
-            archiveArtifacts 'u-boot-pistachio-nor.img'
+            archiveArtifacts 'u-boot-pistachio*.img'
         }
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -1043,6 +1043,11 @@ u-boot-pistachio-nor.img: u-boot-dtb.img u-boot-spl-pistachio.bimg FORCE
 	@dd if=/dev/zero of=$@ bs=4K count=384 conv=notrunc
 	@dd if=u-boot-spl-pistachio.bimg of=$@ bs=4K count=128 conv=notrunc
 	@dd if=u-boot-dtb.img of=$@ bs=4K count=256 seek=128 conv=notrunc
+ifeq ($(UBOOTRELEASE),$(UBOOTVERSION))
+	-mv  u-boot-pistachio-nor.img u-boot-$(subst $\",,$(CONFIG_SYS_CONFIG_NAME))-$(UBOOTVERSION).img
+else
+	-mv u-boot-pistachio-nor.img u-boot-$(subst $\",,$(CONFIG_SYS_CONFIG_NAME))-$(UBOOTRELEASE).img
+endif
 
 # x86 uses a large ROM. We fill it with 0xff, put the 16-bit stuff (including
 # reset vector) at the top, Intel ME descriptor at the bottom, and U-Boot in

--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@ For the MIPS official toolchain see
 	$ make CROSS_COMPILE=<toolchain-prefix> pistachio_marduk_defconfig
 	$ make CROSS_COMPILE=<toolchain-prefix>
 
-This will generate u-boot-pistachio-nor.img
+This will generate `u-boot-pistachio_<board_name>-<version>.img`
+
+    eg. u-boot-pistachio_marduk-2015.10-v1.0.4.img
+
+OR `u-boot-pistachio_<board_name>-<version>-<githash>.img`, if there are extra commits above the tag.
+
+    e.g. u-boot-pistachio_marduk-2015.10-v1.0.4-g75cbe38.img
 
 ## Flash it onto your Ci40
 See our [docs](https://docs.creatordev.io/ci40/guides/openwrt-platform/#flashing-u-boot-binary).


### PR DESCRIPTION
This connects #28 
Name of the file when top commit is annotated and EXTRAVERSION  = v1.0.4 -> u-boot-pistachio_marduk-2015.10-v1.0.4.img
else
u-boot-pistachio_marduk-2015.10-v1.0.4-00004-gcd3b541.img
Signed-off-by: Avinash Tahakik <avinashtahakik@imgtec.com>